### PR TITLE
Add GottaSnatchEmAll and Dominoes exercises to Java track

### DIFF
--- a/dominoes/src/main/java/Domino.java
+++ b/dominoes/src/main/java/Domino.java
@@ -1,0 +1,38 @@
+// This class can't be changed by the solution.
+//
+class Domino {
+    private int left;
+    private int right;
+    private int hash;
+
+    Domino(int left, int right) {
+        if (left < 0 || left > 9 || right < 0 || right > 9) {
+            throw new IllegalArgumentException("Domino tiles must have a number between 0 and 9 on each side");
+        }
+        this.left = left;
+        this.right = right;
+        this.hash = Integer.min(left, right) + Integer.max(left, right) * 10;
+    }
+
+    int getLeft() {
+        return this.left;
+    }
+
+    int getRight() {
+        return this.right;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Domino)) {
+            return false;
+        }
+        Domino otherDomino = (Domino) o;
+        return this.hash == otherDomino.hash;
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+}

--- a/dominoes/src/main/java/Dominoes.java
+++ b/dominoes/src/main/java/Dominoes.java
@@ -1,0 +1,42 @@
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Predicate;
+
+class Dominoes {
+    private static final ChainNotFoundException CHAIN_NOT_FOUND_EXCEPTION =
+            new ChainNotFoundException("No domino chain found.");
+
+    private static Predicate<Domino> matchesNumber(int number) {
+        return domino -> domino.getRight() == number || domino.getLeft() == number;
+    }
+
+    List<Domino> formChain(List<Domino> inputDominoes) throws ChainNotFoundException {
+        if (inputDominoes == null || inputDominoes.isEmpty()) {
+            return inputDominoes;
+        }
+        var dominoes = new LinkedList<>(inputDominoes);
+        var result = new LinkedList<Domino>();
+        var firstDomino = dominoes.removeFirst();
+        result.add(firstDomino);
+        var chainNumber = firstDomino.getRight();
+
+        while (!dominoes.isEmpty()) {
+            var nextDomino = dominoes.stream()
+                    .filter(matchesNumber(chainNumber))
+                    .findAny()
+                    .orElseThrow(() -> CHAIN_NOT_FOUND_EXCEPTION);
+            dominoes.remove(nextDomino);
+            if (nextDomino.getRight() == chainNumber) {
+                nextDomino = new Domino(nextDomino.getRight(), nextDomino.getLeft());
+            }
+            result.add(nextDomino);
+            chainNumber = nextDomino.getRight();
+        }
+
+        if (firstDomino.getLeft() == chainNumber) {
+            return result;
+        }
+        throw CHAIN_NOT_FOUND_EXCEPTION;
+    }
+
+}

--- a/gotta-snatch-em-all/README.md
+++ b/gotta-snatch-em-all/README.md
@@ -1,0 +1,151 @@
+# Gotta Snatch 'Em All
+
+Welcome to Gotta Snatch 'Em All on Exercism's Java Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+If you get stuck on the exercise, check out `HINTS.md`, but try and solve it without using those first :)
+
+## Introduction
+
+## Sets
+
+A [`Set`][set-docs] is an unordered collection that (unlike `List`) is guaranteed to not contain any duplicate values.
+
+The generic type parameter of the `Set` interface denotes the type of the elements contained in the `Set`:
+
+```java
+Set<Integer> ints = Set.of(1, 2, 3);
+Set<String> strings = Set.of("alpha", "beta", "gamma");
+Set<Object> mixed = Set.of(1, false, "foo");
+```
+
+Note that the `Set.of()` method creates an [_unmodifiable_][unmodifiable-set-docs] `Set` instance.
+Trying to call methods like `add` and `remove` on this instance will result in an exception at run-time.
+
+To create a modifiable `Set`, you need to instantiate a class that implements the `Set` interface.
+The most-used built-in class that implements this interface is the [`HashSet`][hashset-docs] class.
+
+```java
+Set<Integer> ints = new HashSet<>();
+```
+
+The `Set` interface extends from the [`Collection`][collection-docs] and [`Iterable`][iterable-docs] interfaces, and therefore shares a lot of methods with other types of collections.
+A notable difference to the `Collection` interface, however, is that methods like `add` and `remove` return a `boolean` (instead of `void`) which indicates whether the item was contained in the set when that method was called:
+
+```java
+Set<Integer> set = new HashSet<>();
+set.add(1);
+// => true
+set.add(2);
+// => true
+set.add(1);
+// => false
+set.size();
+// => 2
+set.contains(1);
+// => true
+set.contains(3);
+// => false
+set.remove(3);
+// => false
+set.remove(2);
+// => true
+set.size();
+// => 1
+```
+
+[collection-docs]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Collection.html
+[hashset-docs]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/HashSet.html
+[iterable-docs]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Iterable.html
+[set-docs]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Set.html
+[unmodifiable-set-docs]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Set.html#unmodifiable
+
+## Instructions
+
+Your nostalgia for Blorkemon™️ cards is showing no sign of slowing down, you even started collecting them again, and you
+are getting your friends to join you.
+
+In this exercise, you will use the `Set` interface to help you manage your collection, since duplicate cards are not
+important when your goal is to get all existing cards.
+
+## 1. Start a collection
+
+You just found your old stash of Blorkemon™️ cards!
+The stash contains a bunch of duplicate cards, so it's time to start a new collection by removing the duplicates.
+
+You really want your friends to join your Blorkemon™️ madness, and the best way is to kickstart their collection by
+giving them one card.
+
+Implement the `newCollection` method, which transforms a list of cards into a `Set` representing your new collection.
+
+```java
+GottaSnatchEmAll.newCollection(List.of("Newthree", "Newthree", "Newthree"));
+// => {"Newthree"}
+```
+
+## 2. Grow the collection
+
+Once you have a collection, it takes a life of its own and must grow.
+
+Implement the `addCard` method, which takes a new card and your current set of collected cards.
+The method should add the new card to the collection if it isn't already present, and should return a `boolean`
+indicating whether the collection was updated.
+
+```java
+Set<String> collection = GottaSnatchEmAll.newCollection("Newthree");
+GottaSnatchEmAll.addCard("Scientuna",collection);
+// => true
+
+collection.contains("Scientuna");
+// => true
+```
+
+## 3. Start trading
+
+You really want your friends to join your Blorkemon™️ madness, so it's time to start trading!
+
+Not every trade is worth doing, or can be done at all.
+You cannot trade a card you don't have, and you shouldn't trade a card for one that you already have.
+
+Implement the `canTrade` method, that takes your current collection and the collection of one of your friends.
+It should return a `boolean` indicating whether a trade is possible, following the rules above.
+
+```java
+Set<String> myCollection = Set.of("Newthree");
+Set<String> theirCollection = Set.of("Scientuna");
+GottaSnatchEmAll.canTrade(myCollection, theirCollection);
+// => true
+```
+
+## 4. Identify common cards
+
+You and your Blorkemon™️ enthusiast friends gather and wonder which cards are the most common.
+
+Implement the `commonCards` method, which takes a list of collections and returns a collection of cards that all collections
+have.
+
+```java
+GottaSnatchEmAll.commonCards(List.of(Set.of("Scientuna"), Set.of("Newthree","Scientuna")));
+// => {"Scientuna"}
+```
+
+## 5. All of the cards
+
+Do you and your friends collectively own all of the Blorkemon™️ cards?
+
+Implement the `allCards` method, which takes a list of collections and returns a collection of all different cards in
+all the collections combined.
+
+```java
+GottaSnatchEmAll.allCards(List.of(Set.of("Scientuna"), Set.of("Newthree","Scientuna")));
+// => {"Newthree", "Scientuna"}
+```
+
+## Source
+
+### Created by
+
+- @sanderploegsma
+
+### Contributed to by
+
+- @kahgoh

--- a/gotta-snatch-em-all/build.gradle
+++ b/gotta-snatch-em-all/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id "java"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform("org.junit:junit-bom:5.10.0")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+    testImplementation "org.assertj:assertj-core:3.25.1"
+}
+
+test {
+    useJUnitPlatform()
+
+    testLogging {
+        exceptionFormat = "full"
+        showStandardStreams = true
+        events = ["passed", "failed", "skipped"]
+    }
+}

--- a/gotta-snatch-em-all/src/main/java/GottaSnatchEmAll.java
+++ b/gotta-snatch-em-all/src/main/java/GottaSnatchEmAll.java
@@ -1,0 +1,34 @@
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.function.Predicate.not;
+
+class GottaSnatchEmAll {
+
+    static Set<String> newCollection(List<String> cards) {
+        return Set.copyOf(cards);
+    }
+
+    static boolean addCard(String card, Set<String> collection) {
+        return collection.add(card);
+    }
+
+    static boolean canTrade(Set<String> myCollection, Set<String> theirCollection) {
+        return !myCollection.isEmpty() && theirCollection.stream().anyMatch(not(myCollection::contains));
+    }
+
+    static Set<String> commonCards(List<Set<String>> collections) {
+        return collections.stream()
+                .flatMap(Set::stream)
+                .distinct()
+                .filter(card -> collections.stream().allMatch(set -> set.contains(card)))
+                .collect(Collectors.toSet());
+    }
+
+    static Set<String> allCards(List<Set<String>> collections) {
+        return collections.stream()
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+    }
+}

--- a/gotta-snatch-em-all/src/test/java/GottaSnatchEmAllTest.java
+++ b/gotta-snatch-em-all/src/test/java/GottaSnatchEmAllTest.java
@@ -1,0 +1,215 @@
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GottaSnatchEmAllTest {
+
+    @Test
+    @Tag("task:1")
+    @DisplayName("newCollection returns an empty set when given an empty list")
+    void testNewCollectionEmptyList() {
+        assertThat(GottaSnatchEmAll.newCollection(List.of())).isEmpty();
+    }
+
+    @Test
+    @Tag("task:1")
+    @DisplayName("newCollection returns a set with one card when given a list with one card")
+    void testNewCollectionSingletonList() {
+        List<String> cards = List.of("Bleakachu");
+        Set<String> expected = Set.of("Bleakachu");
+        assertThat(GottaSnatchEmAll.newCollection(cards)).isEqualTo(expected);
+    }
+
+    @Test
+    @Tag("task:1")
+    @DisplayName("newCollection returns a set with one card when given a list with one repeated card")
+    void testNewCollectionListWithDuplicates() {
+        List<String> cards = List.of("Bleakachu", "Bleakachu");
+        Set<String> expected = Set.of("Bleakachu");
+        assertThat(GottaSnatchEmAll.newCollection(cards)).isEqualTo(expected);
+    }
+
+    @Test
+    @Tag("task:1")
+    @DisplayName("newCollection returns a set with two cards when given a list with two unique cards")
+    void testNewCollectionListWithoutDuplicates() {
+        List<String> cards = List.of("Bleakachu", "Newthree");
+        Set<String> expected = Set.of("Bleakachu", "Newthree");
+        assertThat(GottaSnatchEmAll.newCollection(cards)).isEqualTo(expected);
+    }
+
+    @Test
+    @Tag("task:2")
+    @DisplayName("addCard returns true when the collection does not yet contain the new card")
+    void testAddCardReturnsTrueWhenCardNotInCollection() {
+        Set<String> collection = new HashSet<>();
+        assertThat(GottaSnatchEmAll.addCard("Veevee", collection)).isTrue();
+    }
+
+    @Test
+    @Tag("task:2")
+    @DisplayName("addCard returns false when the collection already contains the new card")
+    void testAddCardReturnsFalseWhenCardAlreadyInCollection() {
+        Set<String> collection = new HashSet<>(Set.of("Veevee"));
+        assertThat(GottaSnatchEmAll.addCard("Veevee", collection)).isFalse();
+    }
+
+    @Test
+    @Tag("task:2")
+    @DisplayName("addCard adds the card to the collection when it is a new card")
+    void testAddCardShouldAddNewCardToCollection() {
+        Set<String> collection = new HashSet<>();
+        Set<String> expected = Set.of("Veevee");
+        GottaSnatchEmAll.addCard("Veevee", collection);
+        assertThat(collection).isEqualTo(expected);
+    }
+
+    @Test
+    @Tag("task:2")
+    @DisplayName("addCard doesn't add the card to the collection when it already contains the new card")
+    void testAddCardShouldNotAddExistingCardToCollection() {
+        Set<String> collection = new HashSet<>(Set.of("Veevee"));
+        Set<String> expected = Set.of("Veevee");
+        GottaSnatchEmAll.addCard("Veevee", collection);
+        assertThat(collection).isEqualTo(expected);
+    }
+
+    @Test
+    @Tag("task:3")
+    @DisplayName("canTrade returns false when both collections are empty")
+    void testCanTradeBothCollectionsEmpty() {
+        Set<String> myCollection = new HashSet<>();
+        Set<String> theirCollection = new HashSet<>();
+        assertThat(GottaSnatchEmAll.canTrade(myCollection, theirCollection)).isFalse();
+    }
+
+    @Test
+    @Tag("task:3")
+    @DisplayName("canTrade returns false when my collections is empty")
+    void testCanTradeMyCollectionsEmpty() {
+        Set<String> myCollection = new HashSet<>();
+        Set<String> theirCollection = new HashSet<>(Set.of("Bleakachu"));
+        assertThat(GottaSnatchEmAll.canTrade(myCollection, theirCollection)).isFalse();
+    }
+
+    @Test
+    @Tag("task:3")
+    @DisplayName("canTrade returns false when their collections is empty")
+    void testCanTradeTheirCollectionsEmpty() {
+        Set<String> myCollection = new HashSet<>(Set.of("Bleakachu"));
+        Set<String> theirCollection = new HashSet<>();
+        assertThat(GottaSnatchEmAll.canTrade(myCollection, theirCollection)).isFalse();
+    }
+
+    @Test
+    @Tag("task:3")
+    @DisplayName("canTrade returns false when both collections have the same cards")
+    void testCanTradeBothCollectionsHaveSameCards() {
+        Set<String> myCollection = new HashSet<>(Set.of("Gyros", "Garilord"));
+        Set<String> theirCollection = new HashSet<>(Set.of("Garilord", "Gyros"));
+        assertThat(GottaSnatchEmAll.canTrade(myCollection, theirCollection)).isFalse();
+    }
+
+    @Test
+    @Tag("task:3")
+    @DisplayName("canTrade returns true when both collections have unique cards")
+    void testCanTradeBothCollectionsHaveUniqueCards() {
+        Set<String> myCollection = new HashSet<>(Set.of("Gyros"));
+        Set<String> theirCollection = new HashSet<>(Set.of("Garilord"));
+        assertThat(GottaSnatchEmAll.canTrade(myCollection, theirCollection)).isTrue();
+    }
+
+    @Test
+    @Tag("task:3")
+    @DisplayName("canTrade returns true when both collections have at least one card the other doesn't have")
+    void testCanTradeBothCollectionsMixedCards() {
+        Set<String> myCollection = new HashSet<>(Set.of("Gyros", "Garilord", "Bleakachu"));
+        Set<String> theirCollection = new HashSet<>(Set.of("Garilord", "Veevee", "Gyros"));
+        assertThat(GottaSnatchEmAll.canTrade(myCollection, theirCollection)).isTrue();
+    }
+
+    @Test
+    @Tag("task:3")
+    @DisplayName("canTrade returns true when my collection is a non-empty subset of their collection")
+    void testCanTradeMyCollectionSubsetOfTheirCollection() {
+        Set<String> myCollection = new HashSet<>(Set.of("Gyros", "Garilord"));
+        Set<String> theirCollection = new HashSet<>(Set.of("Garilord", "Veevee", "Gyros"));
+        assertThat(GottaSnatchEmAll.canTrade(myCollection, theirCollection)).isTrue();
+    }
+
+    @Test
+    @Tag("task:3")
+    @DisplayName("canTrade returns false when their collection is a non-empty subset of my collection")
+    void testCanTradeTheirCollectionSubsetOfMyCollection() {
+        Set<String> myCollection = new HashSet<>(Set.of("Garilord", "Veevee", "Gyros"));
+        Set<String> theirCollection = new HashSet<>(Set.of("Gyros", "Garilord"));
+        assertThat(GottaSnatchEmAll.canTrade(myCollection, theirCollection)).isFalse();
+    }
+
+    @Test
+    @Tag("task:4")
+    @DisplayName("commonCards returns an empty set when all cards are different")
+    void testCommonCardsAllCardsDifferent() {
+        List<Set<String>> collections = List.of(
+                Set.of("Veevee"),
+                Set.of("Bleakachu"),
+                Set.of("Wigglycream")
+        );
+        Set<String> expected = Set.of();
+        assertThat(GottaSnatchEmAll.commonCards(collections)).isEqualTo(expected);
+    }
+
+    @Test
+    @Tag("task:4")
+    @DisplayName("commonCards returns a set with all cards when given a single collection")
+    void testCommonCardsSingleCollection() {
+        List<Set<String>> collections = List.of(
+                Set.of("Veevee", "Wigglycream", "Mayofried")
+        );
+        Set<String> expected = Set.of("Veevee", "Wigglycream", "Mayofried");
+        assertThat(GottaSnatchEmAll.commonCards(collections)).isEqualTo(expected);
+    }
+
+    @Test
+    @Tag("task:4")
+    @DisplayName("commonCards returns a set with cards present in all given collections")
+    void testCommonCardsMultipleCollections() {
+        List<Set<String>> collections = List.of(
+                Set.of("Veevee", "Wigglycream", "Mayofried"),
+                Set.of("Gyros", "Wigglycream", "Shazam"),
+                Set.of("Cooltentbro", "Mayofried", "Wigglycream")
+        );
+        Set<String> expected = Set.of("Wigglycream");
+        assertThat(GottaSnatchEmAll.commonCards(collections)).isEqualTo(expected);
+    }
+
+    @Test
+    @Tag("task:5")
+    @DisplayName("allCards returns a set with all cards when given a single collection")
+    void testAllCardsSingleCollection() {
+        List<Set<String>> collections = List.of(
+                Set.of("Veevee", "Wigglycream", "Mayofried")
+        );
+        Set<String> expected = Set.of("Veevee", "Wigglycream", "Mayofried");
+        assertThat(GottaSnatchEmAll.allCards(collections)).isEqualTo(expected);
+    }
+
+    @Test
+    @Tag("task:5")
+    @DisplayName("allCards returns a set with all cards when given multiple collections")
+    void testAllCardsMultipleCollections() {
+        List<Set<String>> collections = List.of(
+                Set.of("Veevee", "Wigglycream", "Mayofried"),
+                Set.of("Gyros", "Wigglycream", "Shazam"),
+                Set.of("Cooltentbro", "Mayofried", "Wigglycream")
+        );
+        Set<String> expected = Set.of("Cooltentbro", "Gyros", "Mayofried", "Shazam", "Veevee", "Wigglycream");
+        assertThat(GottaSnatchEmAll.allCards(collections)).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
This commit introduces two new exercises to the Java track. For the GottaSnatchEmAll exercise, instructions, methods, tests and helper classes have been added to manage a Blorkemon cards collection using the Set interface. The Dominoes exercise involves the creation of Domino and Dominoes classes with appropriate methods and tests for domino chain formation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `Domino` class for representing domino tiles with methods for tile comparison.
	- Added a `Dominoes` class that includes functionality to form a chain of dominoes, with error handling for invalid chains.
	- Launched a new `GottaSnatchEmAll` class for managing card collections, including functionalities for creating, adding, trading, and retrieving cards across multiple collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->