### PR TITLE
Add Annalyn's Infiltration quest logic

### DIFF
--- a/annalyns-infiltration/README.md
+++ b/annalyns-infiltration/README.md
@@ -1,0 +1,78 @@
+# Annalyn's Infiltration
+
+Welcome to Annalyn's Infiltration on Exercism's Java Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+If you get stuck on the exercise, check out `HINTS.md`, but try and solve it without using those first :)
+
+## Introduction
+
+Booleans in Java are represented by the `boolean` type, which values can be either `true` or `false`.
+
+Java supports three boolean operators: `!` (NOT), `&&` (AND), and `||` (OR).
+
+## Instructions
+
+In this exercise, you'll be implementing the quest logic for a new RPG game a friend is developing. The game's main character is Annalyn, a brave girl with a fierce and loyal pet dog. Unfortunately, disaster strikes, as her best friend was kidnapped while searching for berries in the forest. Annalyn will try to find and free her best friend, optionally taking her dog with her on this quest.
+
+After some time spent following her best friend's trail, she finds the camp in which her best friend is imprisoned. It turns out there are two kidnappers: a mighty knight and a cunning archer.
+
+Having found the kidnappers, Annalyn considers which of the following actions she can engage in:
+
+- Fast attack: a fast attack can be made if the knight is sleeping, as it takes time for him to get his armor on, so he will be vulnerable.
+- Spy: the group can be spied upon if at least one of them is awake. Otherwise, spying is a waste of time.
+- Signal prisoner: the prisoner can be signalled using bird sounds if the prisoner is awake and the archer is sleeping, as archers are trained in bird signaling, so they could intercept the message.
+- Free prisoner: if the prisoner is awake and the other two characters are sleeping, a sneaky entry into the camp can free the prisoner. This won't work if the prisoner is sleeping, as the prisoner will be startled by the sudden appearance of her friend and the knight and archer will be awoken. The prisoner can also be freed if the archer is sleeping and Annalyn has her pet dog with her, as the knight will be scared by the dog and will withdraw, and the archer can't equip his bow fast enough to prevent the prisoner from being freed.
+
+You have four tasks: to implement the logic for determining if the above actions are available based on the state of the three characters found in the forest and whether Annalyn's pet dog is present or not.
+
+## 1. Check if a fast attack can be made
+
+Implement the (_static_) `AnnalynsInfiltration.canFastAttack()` method that takes a boolean value that indicates if the knight is awake. This method returns `true` if a fast attack can be made based on the state of the knight. Otherwise, returns `false`:
+
+```java
+boolean knightIsAwake = true;
+AnnalynsInfiltration.canFastAttack(knightIsAwake);
+// => false
+```
+
+## 2. Check if the group can be spied upon
+
+Implement the (_static_) `AnnalynsInfiltration.canSpy()` method that takes three boolean values, indicating if the knight, archer and the prisoner, respectively, are awake. The method returns `true` if the group can be spied upon, based on the state of the three characters. Otherwise, returns `false`:
+
+```java
+boolean knightIsAwake = false;
+boolean archerIsAwake = true;
+boolean prisonerIsAwake = false;
+AnnalynsInfiltration.canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake);
+// => true
+```
+
+## 3. Check if the prisoner can be signalled
+
+Implement the (_static_) `AnnalynsInfiltration.canSignalPrisoner()` method that takes two boolean values, indicating if the archer and the prisoner, respectively, are awake. The method returns `true` if the prisoner can be signalled, based on the state of the two characters. Otherwise, returns `false`:
+
+```java
+boolean archerIsAwake = false;
+boolean prisonerIsAwake = true;
+AnnalynsInfiltration.canSignalPrisoner(archerIsAwake, prisonerIsAwake);
+// => true
+```
+
+## 4. Check if the prisoner can be freed
+
+Implement the (_static_) `AnnalynsInfiltration.canFreePrisoner()` method that takes four boolean values. The first three parameters indicate if the knight, archer and the prisoner, respectively, are awake. The last parameter indicates if Annalyn's pet dog is present. The method returns `true` if the prisoner can be freed based on the state of the three characters and Annalyn's pet dog presence. Otherwise, it returns `false`:
+
+```java
+boolean knightIsAwake = false;
+boolean archerIsAwake = true;
+boolean prisonerIsAwake = false;
+boolean petDogIsPresent = false;
+AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake, prisonerIsAwake, petDogIsPresent);
+// => false
+```
+
+## Source
+
+### Created by
+
+- @mikedamay

--- a/annalyns-infiltration/build.gradle
+++ b/annalyns-infiltration/build.gradle
@@ -1,0 +1,24 @@
+apply plugin: "java"
+apply plugin: "eclipse"
+apply plugin: "idea"
+
+// set default encoding to UTF-8
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  testImplementation "junit:junit:4.13"
+  testImplementation "org.assertj:assertj-core:3.15.0"
+}
+
+test {
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
+}

--- a/annalyns-infiltration/src/main/java/AnnalynsInfiltration.java
+++ b/annalyns-infiltration/src/main/java/AnnalynsInfiltration.java
@@ -1,0 +1,17 @@
+class AnnalynsInfiltration {
+    public static boolean canFastAttack(boolean knightIsAwake) {
+        return !knightIsAwake;
+    }
+
+    public static boolean canSpy(boolean knightIsAwake, boolean archerIsAwake, boolean prisonerIsAwake) {
+        return knightIsAwake || archerIsAwake || prisonerIsAwake;
+    }
+
+    public static boolean canSignalPrisoner(boolean archerIsAwake, boolean prisonerIsAwake) {
+        return !archerIsAwake && prisonerIsAwake;
+    }
+
+    public static boolean canFreePrisoner(boolean knightIsAwake, boolean archerIsAwake, boolean prisonerIsAwake, boolean petDogIsPresent) {
+        return  !archerIsAwake && (!knightIsAwake && prisonerIsAwake || petDogIsPresent);
+    }
+}

--- a/annalyns-infiltration/src/test/java/AnnalynsInfiltrationTest.java
+++ b/annalyns-infiltration/src/test/java/AnnalynsInfiltrationTest.java
@@ -1,0 +1,269 @@
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnnalynsInfiltrationTest {
+    @Test
+    public void cannot_execute_fast_attack_if_knight_is_awake() {
+        boolean knightIsAwake = true;
+        assertThat(AnnalynsInfiltration.canFastAttack(knightIsAwake)).isFalse();
+    }
+
+    @Test
+    public void can_execute_fast_attack_if_knight_is_sleeping() {
+        boolean knightIsAwake = false;
+        assertThat(AnnalynsInfiltration.canFastAttack(knightIsAwake)).isTrue();
+    }
+
+    @Test
+    public void cannot_spy_if_everyone_is_sleeping() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = false;
+        assertThat(AnnalynsInfiltration.canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).isFalse();
+    }
+
+    @Test
+    public void can_spy_if_everyone_but_knight_is_sleeping() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = false;
+        assertThat(AnnalynsInfiltration.canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).isTrue();
+    }
+
+    @Test
+    public void can_spy_if_everyone_but_archer_is_sleeping() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = false;
+        assertThat(AnnalynsInfiltration.canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).isTrue();
+    }
+
+    @Test
+    public void can_spy_if_everyone_but_prisoner_is_sleeping() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = true;
+        assertThat(AnnalynsInfiltration.canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).isTrue();
+    }
+
+    @Test
+    public void can_spy_if_only_knight_is_sleeping() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = true;
+        assertThat(AnnalynsInfiltration.canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).isTrue();
+    }
+
+    @Test
+    public void can_spy_if_only_archer_is_sleeping() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = true;
+        assertThat(AnnalynsInfiltration.canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).isTrue();
+    }
+
+    @Test
+    public void can_spy_if_only_prisoner_is_sleeping() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = false;
+        assertThat(AnnalynsInfiltration.canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).isTrue();
+    }
+
+    @Test
+    public void can_spy_if_everyone_is_awake() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = true;
+        assertThat(AnnalynsInfiltration.canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).isTrue();
+    }
+
+    @Test
+    public void can_signal_prisoner_ifarcher_is_sleeping_and_prisoner_is_awake() {
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = true;
+        assertThat(AnnalynsInfiltration.canSignalPrisoner(archerIsAwake, prisonerIsAwake)).isTrue();
+    }
+
+    @Test
+    public void cannot_signal_prisoner_ifarcher_is_awake_and_prisoner_is_sleeping() {
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = false;
+        assertThat(AnnalynsInfiltration.canSignalPrisoner(archerIsAwake, prisonerIsAwake)).isFalse();
+    }
+
+    @Test
+    public void cannot_signal_prisoner_ifarcher_and_prisoner_are_both_sleeping() {
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = false;
+        assertThat(AnnalynsInfiltration.canSignalPrisoner(archerIsAwake, prisonerIsAwake)).isFalse();
+    }
+
+    @Test
+    public void cannot_signal_prisoner_ifarcher_and_prisoner_are_both_awake() {
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = true;
+        assertThat(AnnalynsInfiltration.canSignalPrisoner(archerIsAwake, prisonerIsAwake)).isFalse();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_everyone_is_awake_and_pet_dog_is_present() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = true;
+        boolean petDogIsPresent = true;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_everyone_is_awake_and_pet_dog_is_absent() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = true;
+        boolean petDogIsPresent = false;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+
+    @Test
+    public void can_release_prisoner_if_everyone_is_asleep_and_pet_dog_is_present() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = false;
+        boolean petDogIsPresent = true;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isTrue();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_everyone_is_asleep_and_pet_dog_is_absent() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = false;
+        boolean petDogIsPresent = false;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+
+    @Test
+    public void can_release_prisoner_if_only_prisoner_is_awake_and_pet_dog_is_present() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = true;
+        boolean petDogIsPresent = true;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isTrue();
+    }
+
+    @Test
+    public void can_release_prisoner_if_only_prisoner_is_awake_and_pet_dog_is_absent() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = true;
+        boolean petDogIsPresent = false;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isTrue();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_only_archer_is_awake_and_pet_dog_is_present() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = false;
+        boolean petDogIsPresent = true;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_only_archer_is_awake_and_pet_dog_is_absent() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = false;
+        boolean petDogIsPresent = false;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+
+    @Test
+    public void can_release_prisoner_if_only_knight_is_awake_and_pet_dog_is_present() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = false;
+        boolean petDogIsPresent = true;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isTrue();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_only_knight_is_awake_and_pet_dog_is_absent() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = false;
+        boolean petDogIsPresent = false;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_only_knight_is_asleep_and_pet_dog_is_present() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = true;
+        boolean petDogIsPresent = true;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_only_knight_is_asleep_and_pet_dog_is_absent() {
+        boolean knightIsAwake = false;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = true;
+        boolean petDogIsPresent = false;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+
+    @Test
+    public void can_release_prisoner_if_only_archer_is_asleep_and_pet_dog_is_present() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = true;
+        boolean petDogIsPresent = true;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isTrue();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_only_archer_is_asleep_and_pet_dog_is_absent() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = false;
+        boolean prisonerIsAwake = true;
+        boolean petDogIsPresent = false;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_only_prisoner_is_asleep_and_pet_dog_is_present() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = false;
+        boolean petDogIsPresent = true;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+
+    @Test
+    public void cannot_release_prisoner_if_only_prisoner_is_asleep_and_pet_dog_is_absent() {
+        boolean knightIsAwake = true;
+        boolean archerIsAwake = true;
+        boolean prisonerIsAwake = false;
+        boolean petDogIsPresent = false;
+        assertThat(AnnalynsInfiltration.canFreePrisoner(knightIsAwake, archerIsAwake,
+                prisonerIsAwake, petDogIsPresent)).isFalse();
+    }
+}


### PR DESCRIPTION
This commit adds the Annalyn's Infiltration quest logic into the RPG game. The logic includes implementation of actions such as fast attacks, spying, signalling the prisoner and freeing the prisoner, based on the awake/asleep states of characters in the game and the presence of Annalyn's pet dog. As part of the commit, tests for the quest logic have also been added.

@coderabbitai ignore