### PR TITLE
Add new Sudoku solver with associated tests

### DIFF
--- a/killer-sudoku-helper/src/main/java/KillerSudokuHelper.java
+++ b/killer-sudoku-helper/src/main/java/KillerSudokuHelper.java
@@ -1,0 +1,11 @@
+import java.util.List;
+
+public class KillerSudokuHelper {
+    List<List<Integer>> combinationsInCage(Integer cageSum, Integer cageSize, List<Integer> exclude) {
+        return new SudokuSolver(exclude).combinations(cageSum, cageSize);
+    }
+
+    List<List<Integer>> combinationsInCage(Integer cageSum, Integer cageSize) {
+        return new SudokuSolver(List.of()).combinations(cageSum, cageSize);
+    }
+}

--- a/killer-sudoku-helper/src/main/java/SudokuSolver.java
+++ b/killer-sudoku-helper/src/main/java/SudokuSolver.java
@@ -1,0 +1,27 @@
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.function.Predicate.not;
+
+public record SudokuSolver(List<Integer> exclude) {
+    private static final int MAX_DIGIT = 9;
+
+    public List<List<Integer>> combinations(int sum, int size) {
+        return combinations(1, sum, size)
+                .map(IntStream::boxed)
+                .map(Stream::toList)
+                .toList();
+    }
+
+    private Stream<IntStream> combinations(int start, int sum, int size) {
+        if (size == 1) {
+            var solution = start <= sum && sum <= MAX_DIGIT && !exclude.contains(sum);
+            return solution ? Stream.of(IntStream.of(sum)) : Stream.empty();
+        }
+        return IntStream.rangeClosed(start, MAX_DIGIT - size + 1).boxed()
+                .filter(not(exclude::contains))
+                .flatMap(i -> combinations(i + 1, sum - i, size - 1)
+                        .map(s -> IntStream.concat(IntStream.of(i), s)));
+    }
+}

--- a/killer-sudoku-helper/src/test/java/KillerSudokuHelperTest.java
+++ b/killer-sudoku-helper/src/test/java/KillerSudokuHelperTest.java
@@ -1,0 +1,62 @@
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KillerSudokuHelperTest {
+
+    private KillerSudokuHelper helper;
+
+    @BeforeEach
+    void setUp() {
+        helper = new KillerSudokuHelper();
+    }
+
+    @Test
+    @DisplayName("Trivial 1-digit cages -> 1 to 9")
+    public void testTrivialOneDigitCages() {
+        for (int n = 1; n <= 9; n++) {
+            List<List<Integer>> expected = List.of(List.of(n));
+            assertThat(helper.combinationsInCage(n, 1)).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    @DisplayName("Cage with sum 45 contains all digits 1:9")
+    public void testCageWithSum45ContainsAllDigits() {
+        List<List<Integer>> expected = List.of(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        assertThat(helper.combinationsInCage(45, 9)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Cage with only 1 possible combination")
+    public void testCageWithOnlyOnePossibleCombination() {
+        List<List<Integer>> expected = List.of(List.of(1, 2, 4));
+        assertThat(helper.combinationsInCage(7, 3)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Cage with several combinations")
+    public void testCageWithSeveralCombinations() {
+        List<List<Integer>> expected = List.of(
+                List.of(1, 9),
+                List.of(2, 8),
+                List.of(3, 7),
+                List.of(4, 6)
+        );
+        assertThat(helper.combinationsInCage(10, 2)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Cage with several combinations that is restricted")
+    public void testCageWithSeveralCombinationsThatIsRestricted() {
+        List<List<Integer>> expected = List.of(
+                List.of(2, 8),
+                List.of(3, 7)
+        );
+        assertThat(helper.combinationsInCage(10, 2, List.of(1, 4))).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
The commit introduces the SudokuSolver and KillerSudokuHelper classes, for finding possible combinations in cages of varying size and sum. Corresponding helper tests for different cage scenarios have also been created to ensure valid functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `Killer Sudoku Helper` tool to generate potential number combinations for cage sums in Killer Sudoku puzzles.
  - Added functionality in `Sudoku Solver` to generate combinations of integers for general Sudoku solving based on specific constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->