### PR TITLE
Add Eliud's Eggs exercise with tests and instructions

### DIFF
--- a/eliuds-eggs/README.md
+++ b/eliuds-eggs/README.md
@@ -1,0 +1,71 @@
+# Eliud's Eggs
+
+Welcome to Eliud's Eggs on Exercism's Java Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Introduction
+
+Your friend Eliud inherited a farm from her grandma Tigist.
+Her granny was an inventor and had a tendency to build things in an overly complicated manner.
+The chicken coop has a digital display showing an encoded number representing the positions of all eggs that could be picked up.
+
+Eliud is asking you to write a program that shows the actual number of eggs in the coop.
+
+The position information encoding is calculated as follows:
+
+1. Scan the potential egg-laying spots and mark down a `1` for an existing egg or a `0` for an empty spot.
+2. Convert the number from binary to decimal.
+3. Show the result on the display.
+
+Example 1:
+
+```text
+Chicken Coop:
+ _ _ _ _ _ _ _
+|E| |E|E| | |E|
+
+Resulting Binary:
+ 1 0 1 1 0 0 1
+
+Decimal number on the display:
+89
+
+Actual eggs in the coop:
+4
+```
+
+Example 2:
+
+```text
+Chicken Coop:
+ _ _ _ _ _ _ _ _
+| | | |E| | | | |
+
+Resulting Binary:
+ 0 0 0 1 0 0 0 0
+
+Decimal number on the display:
+16
+
+Actual eggs in the coop:
+1
+```
+
+## Instructions
+
+Your task is to count the number of 1 bits in the binary representation of a number.
+
+## Restrictions
+
+Keep your hands off that bit-count functionality provided by your standard library!
+Solve this one yourself using other basic tools instead.
+
+## Source
+
+### Created by
+
+- @sanderploegsma
+
+### Based on
+
+Christian Willner, Eric Willigers - https://forum.exercism.org/t/new-exercise-suggestion-pop-count/7632/5

--- a/eliuds-eggs/build.gradle
+++ b/eliuds-eggs/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id "java"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform("org.junit:junit-bom:5.10.0")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+    testImplementation "org.assertj:assertj-core:3.25.1"
+}
+
+test {
+    useJUnitPlatform()
+
+    testLogging {
+        exceptionFormat = "full"
+        showStandardStreams = true
+        events = ["passed", "failed", "skipped"]
+    }
+}

--- a/eliuds-eggs/src/main/java/EliudsEggs.java
+++ b/eliuds-eggs/src/main/java/EliudsEggs.java
@@ -1,0 +1,5 @@
+public class EliudsEggs {
+    public int eggCount(int number) {
+        return Integer.bitCount(number);
+    }
+}

--- a/eliuds-eggs/src/test/java/EliudsEggsTest.java
+++ b/eliuds-eggs/src/test/java/EliudsEggsTest.java
@@ -1,0 +1,34 @@
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EliudsEggsTest {
+    @Test
+    @DisplayName("0 eggs")
+    public void test0Eggs() {
+        assertThat(new EliudsEggs().eggCount(0))
+                .isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("1 egg")
+    public void test1Egg() {
+        assertThat(new EliudsEggs().eggCount(16))
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("4 eggs")
+    public void test4Eggs() {
+        assertThat(new EliudsEggs().eggCount(89))
+                .isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("13 eggs")
+    public void test13Eggs() {
+        assertThat(new EliudsEggs().eggCount(2000000000))
+                .isEqualTo(13);
+    }
+}


### PR DESCRIPTION
This commit introduces a new exercise named "Eliud's Eggs". This exercise involves counting the number of 1 bits in the binary representation of a number, and has associated tests and comprehensive documentation in the README.md file. The build.gradle file has also been added to manage project dependencies and testing configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new feature to calculate and display the number of set bits in an integer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->