### PR TITLE
Implement Minesweeper board with game logic and tests

### DIFF
--- a/minesweeper/README.md
+++ b/minesweeper/README.md
@@ -1,0 +1,64 @@
+# Minesweeper
+
+Welcome to Minesweeper on Exercism's Java Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Introduction
+
+[Minesweeper][wikipedia] is a popular game where the user has to find the mines using numeric hints that indicate how many mines are directly adjacent (horizontally, vertically, diagonally) to a square.
+
+[wikipedia]: https://en.wikipedia.org/wiki/Minesweeper_(video_game)
+
+## Instructions
+
+Your task is to add the mine counts to empty squares in a completed Minesweeper board.
+The board itself is a rectangle composed of squares that are either empty (`' '`) or a mine (`'*'`).
+
+For each empty square, count the number of mines adjacent to it (horizontally, vertically, diagonally).
+If the empty square has no adjacent mines, leave it empty.
+Otherwise replace it with the adjacent mines count.
+
+For example, you may receive a 5 x 4 board like this (empty spaces are represented here with the '·' character for display on screen):
+
+```text
+·*·*·
+··*··
+··*··
+·····
+```
+
+Which your code should transform into this:
+
+```text
+1*3*1
+13*31
+·2*2·
+·111·
+```
+
+## Source
+
+### Created by
+
+- @stkent
+
+### Contributed to by
+
+- @aadityakulkarni
+- @FridaTveit
+- @hgvanpariya
+- @jmrunkle
+- @jsertel
+- @kytrinyx
+- @lemoncurry
+- @matthewmorgan
+- @matthewstyler
+- @morrme
+- @msomji
+- @muzimuzhi
+- @redshirt4
+- @SleeplessByte
+- @Smarticles101
+- @sshine
+- @vivshaw
+- @Zaldrick

--- a/minesweeper/build.gradle
+++ b/minesweeper/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id "java"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform("org.junit:junit-bom:5.10.0")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+    testImplementation "org.assertj:assertj-core:3.25.1"
+}
+
+test {
+    useJUnitPlatform()
+
+    testLogging {
+        exceptionFormat = "full"
+        showStandardStreams = true
+        events = ["passed", "failed", "skipped"]
+    }
+}

--- a/minesweeper/src/main/java/MinesweeperBoard.java
+++ b/minesweeper/src/main/java/MinesweeperBoard.java
@@ -1,0 +1,40 @@
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.IntStream.range;
+
+public class MinesweeperBoard {
+    private final List<String> inputBoard;
+    private final int rows;
+    private final int cols;
+
+    public MinesweeperBoard(List<String> inputBoard) {
+        this.inputBoard = inputBoard;
+        rows = inputBoard.size();
+        cols = rows > 0 ? inputBoard.getFirst().length() : 0;
+    }
+
+    public List<String> withNumbers() {
+        return range(0, rows).mapToObj(row -> range(0, cols)
+                .map(col -> isMine(row, col) ? '*' : countMines(row, col))
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString()
+        ).collect(Collectors.toList());
+    }
+
+    private char countMines(int row, int col) {
+        int mines = 0;
+        for (int rowIndex = Math.max(0, row - 1); rowIndex < Math.min(rows, row + 2); rowIndex++) {
+            for (int colIndex = Math.max(0, col - 1); colIndex < Math.min(cols, col + 2); colIndex++) {
+                if (isMine(rowIndex, colIndex)) {
+                    mines++;
+                }
+            }
+        }
+        return mines == 0 ? ' ' : Character.forDigit(mines, 10);
+    }
+
+    private boolean isMine(int row, int col) {
+        return inputBoard.get(row).charAt(col) == '*';
+    }
+}

--- a/minesweeper/src/test/java/MinesweeperBoardTest.java
+++ b/minesweeper/src/test/java/MinesweeperBoardTest.java
@@ -1,0 +1,230 @@
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MinesweeperBoardTest {
+
+    @Test
+    public void testInputBoardWithNoRowsAndNoColumns() {
+        List<String> inputBoard = Collections.emptyList();
+        List<String> expectedNumberedBoard = Collections.emptyList();
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testInputBoardWithOneRowAndNoColumns() {
+        List<String> inputBoard = Collections.singletonList("");
+        List<String> expectedNumberedBoard = Collections.singletonList("");
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testInputBoardWithNoMines() {
+        List<String> inputBoard = Arrays.asList(
+                "   ",
+                "   ",
+                "   "
+        );
+
+        List<String> expectedNumberedBoard = Arrays.asList(
+                "   ",
+                "   ",
+                "   "
+        );
+
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testInputBoardWithOnlyMines() {
+        List<String> inputBoard = Arrays.asList(
+                "***",
+                "***",
+                "***"
+        );
+
+        List<String> expectedNumberedBoard = Arrays.asList(
+                "***",
+                "***",
+                "***"
+        );
+
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testInputBoardWithSingleMineAtCenter() {
+        List<String> inputBoard = Arrays.asList(
+                "   ",
+                " * ",
+                "   "
+        );
+
+        List<String> expectedNumberedBoard = Arrays.asList(
+                "111",
+                "1*1",
+                "111"
+        );
+
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testInputBoardWithMinesAroundPerimeter() {
+        List<String> inputBoard = Arrays.asList(
+                "***",
+                "* *",
+                "***"
+        );
+
+        List<String> expectedNumberedBoard = Arrays.asList(
+                "***",
+                "*8*",
+                "***"
+        );
+
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testInputBoardWithSingleRowAndTwoMines() {
+        List<String> inputBoard = Collections.singletonList(
+                " * * "
+        );
+
+        List<String> expectedNumberedBoard = Collections.singletonList(
+                "1*2*1"
+        );
+
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testInputBoardWithSingleRowAndTwoMinesAtEdges() {
+        List<String> inputBoard = Collections.singletonList(
+                "*   *"
+        );
+
+        List<String> expectedNumberedBoard = Collections.singletonList(
+                "*1 1*"
+        );
+
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testInputBoardWithSingleColumnAndTwoMines() {
+        List<String> inputBoard = Arrays.asList(
+                " ",
+                "*",
+                " ",
+                "*",
+                " "
+        );
+
+        List<String> expectedNumberedBoard = Arrays.asList(
+                "1",
+                "*",
+                "2",
+                "*",
+                "1"
+        );
+
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testInputBoardWithSingleColumnAndTwoMinesAtEdges() {
+        List<String> inputBoard = Arrays.asList(
+                "*",
+                " ",
+                " ",
+                " ",
+                "*"
+        );
+
+        List<String> expectedNumberedBoard = Arrays.asList(
+                "*",
+                "1",
+                " ",
+                "1",
+                "*"
+        );
+
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testInputBoardWithMinesInCross() {
+        List<String> inputBoard = Arrays.asList(
+                "  *  ",
+                "  *  ",
+                "*****",
+                "  *  ",
+                "  *  "
+        );
+
+        List<String> expectedNumberedBoard = Arrays.asList(
+                " 2*2 ",
+                "25*52",
+                "*****",
+                "25*52",
+                " 2*2 "
+        );
+
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+    @Test
+    public void testLargeInputBoard() {
+        List<String> inputBoard = Arrays.asList(
+                " *  * ",
+                "  *   ",
+                "    * ",
+                "   * *",
+                " *  * ",
+                "      "
+        );
+
+        List<String> expectedNumberedBoard = Arrays.asList(
+                "1*22*1",
+                "12*322",
+                " 123*2",
+                "112*4*",
+                "1*22*2",
+                "111111"
+        );
+
+        List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
+
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
+    }
+
+}


### PR DESCRIPTION
Add MinesweeperBoard with logic for calculating mine counts and transforming the board. Include comprehensive unit tests for edge cases and various board configurations. Update build files and documentation for setup and usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Minesweeper game board: Players will now see numerical hints on each cell, indicating the count of adjacent mines for clearer gameplay feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->